### PR TITLE
FIX: examples

### DIFF
--- a/examples/cavalier_nugget_particles/main.js
+++ b/examples/cavalier_nugget_particles/main.js
@@ -1,5 +1,8 @@
 window.onload = init;
 
+// animation
+var animation;
+
 function init() {
   var root = new THREERoot();
   root.renderer.setClearColor(0x000000);
@@ -33,9 +36,6 @@ function init() {
       new THREE.Vector3(6, 8, 6)
     )
   };
-
-  // animation
-  var animation;
 
   // gui
   var gui = new dat.GUI();
@@ -130,7 +130,7 @@ function Animation(prefabCount, prefabSize, bounds) {
 
   // each prefab will have a tint of the gold-ish color #d7d2bf
   var colorObj = new THREE.Color('#d7d2bf');
-  var colorHSL = colorObj.getHSL();
+  var colorHSL = colorObj.getHSL(colorObj);
   var h, s, l;
 
   geometry.createAttribute('color', 3, function(data) {

--- a/examples/points_animation/main.js
+++ b/examples/points_animation/main.js
@@ -203,13 +203,10 @@ function Animation() {
     depthWrite: false,
     uniforms: {
       uTime: { type: 'f', value: 0 },
+      size: { type: 'f', value: 10.0 },
+      sizeAttenuation: { type: 'b', value: true },
     },
-    uniformValues: {
-      size: 10.0,
-      sizeAttenuation: true,
-      // all points will have the same color
-      // diffuse: new THREE.Vector3(0xffffff),
-    },
+
     vertexFunctions: [
       BAS.ShaderChunk['ease_expo_in_out'],
     ],


### PR DESCRIPTION
examples/cavalier_nugget_particles

move `var animation;` declaration to top to avoid "animation is not defined error"

pass colorObj to `colorObj.getHSL(colorObj)` to avoid three.js deprecation warning.

-----

examples/points_animation:

remove uniformValues by moving the values directly into the uniforms.

-----

examples/audio_visualizer:

the soundcloud implementation seems broken, the example works fine if i comment all code touching SC and instead load an audio file from my server, the errors seem to imply that your api key has been revoked.

-----

just fyi: all other examples work with three version 0.136.0

```
"node_modules/three": {
      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
```