### PR TITLE
Fix for examples no longer working

### DIFF
--- a/examples/basic_transform/index.html
+++ b/examples/basic_transform/index.html
@@ -16,7 +16,7 @@
 
 <script src="../_lib/TweenMax.min.js"></script>
 <script src="https://unpkg.com/three/build/three.js"></script>
-<script src="https://unpkg.com/three/examples/js/controls/OrbitControls.js"></script>
+<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
 <script src="../../dist/bas.js"></script>
 <script src="../_js/utils.js"></script>
 <script src="../_js/root.js"></script>


### PR DESCRIPTION
That might no be ideal, but that's probably the quickest way to fix the examples. Also, if that solution is accepted, one will need to apply it to all examples where OrbitControls are used :/